### PR TITLE
Mejora visualización de comandos largos agregando salto de linea

### DIFF
--- a/src/components/CardCopyCode.astro
+++ b/src/components/CardCopyCode.astro
@@ -66,7 +66,6 @@ const { textToCopy } = Astro.props
 		animation: fade-message 1s ease-in-out;
 	}
 
-	/* Estilos para la barra de desplazamiento */
 	pre::-webkit-scrollbar {
 		height: 6px;
 	}

--- a/src/components/CardCopyCode.astro
+++ b/src/components/CardCopyCode.astro
@@ -9,7 +9,8 @@ const { textToCopy } = Astro.props
 		class="relative flex min-h-11 items-start justify-between rounded-md bg-slate-300 text-white dark:bg-zinc-900">
 		<pre
 			id="code"
-			class="text-to-copy border-transparent p-2 text-sm text-black dark:text-gray-300 sm:text-base">{textToCopy}</pre>
+			class="text-to-copy w-full border-transparent p-2 text-sm text-black dark:text-gray-300 sm:text-base"
+			style="white-space: pre; overflow-x: auto; max-width: calc(100% - 40px);">{textToCopy}</pre>
 		<button
 			class="button-copy absolute right-0 top-0 h-11 rounded-md border-transparent px-3 text-gray-300 hover:bg-slate-400 dark:bg-zinc-900 dark:hover:bg-zinc-700"
 			><Icon
@@ -63,5 +64,28 @@ const { textToCopy } = Astro.props
 
 	.message-copy.show {
 		animation: fade-message 1s ease-in-out;
+	}
+
+	/* Estilos para la barra de desplazamiento */
+	pre::-webkit-scrollbar {
+		height: 6px;
+	}
+
+	pre::-webkit-scrollbar-track {
+		background: rgba(0, 0, 0, 0.1);
+		border-radius: 3px;
+	}
+
+	pre::-webkit-scrollbar-thumb {
+		background: var(--action-color, #666);
+		border-radius: 3px;
+	}
+
+	.dark pre::-webkit-scrollbar-track {
+		background: rgba(255, 255, 255, 0.1);
+	}
+
+	.dark pre::-webkit-scrollbar-thumb {
+		background: var(--action-color, #999);
 	}
 </style>

--- a/src/components/SeccionListaCopyCode.astro
+++ b/src/components/SeccionListaCopyCode.astro
@@ -11,12 +11,44 @@ const { title, lista, id } = Astro.props
 	<h3 class="mb-5">{title}</h3>
 	{
 		lista.map((elemento) => (
-			<div class="mb-10 sm:ml-10">
+			<div class="comando-contenedor mb-10 sm:ml-10">
 				<p class="mb-5 text-lg font-bold">{elemento.titulo}</p>
-				<CardCopyCode textToCopy={elemento.codigo} />
+				<div class="comando-wrapper">
+					<CardCopyCode textToCopy={elemento.codigo} />
+				</div>
 				{elemento.descripcion && <p>{elemento.descripcion}</p>}
 			</div>
 		))
 	}
 </article>
 <Separador />
+
+<style>
+	.comando-contenedor {
+		width: 100%;
+	}
+
+	.comando-wrapper {
+		width: 100%;
+		max-width: 100%;
+		overflow-wrap: break-word;
+		word-wrap: break-word;
+		word-break: break-word;
+		hyphens: auto;
+	}
+
+	/* Aseguramos que el código dentro de las card también tenga saltos de línea */
+	:global(.comando-wrapper pre),
+	:global(.comando-wrapper code) {
+		white-space: pre-wrap !important;
+		word-break: break-word !important;
+		overflow-wrap: break-word !important;
+		max-width: 100% !important;
+		padding-right: 45px !important; /* Reservamos espacio para el botón de copiar */
+	}
+
+	/* Aseguramos que el botón no tape el texto */
+	:global(.comando-wrapper .button-copy) {
+		z-index: 10;
+	}
+</style>

--- a/src/components/SeccionListaCopyCode.astro
+++ b/src/components/SeccionListaCopyCode.astro
@@ -47,7 +47,6 @@ const { title, lista, id } = Astro.props
 		padding-right: 45px !important; /* Reservamos espacio para el botón de copiar */
 	}
 
-	/* Aseguramos que el botón no tape el texto */
 	:global(.comando-wrapper .button-copy) {
 		z-index: 10;
 	}


### PR DESCRIPTION
- Se mejora la visualizacion de comandos largos agregando un salto de linea, anteriormente se "rompia" el diseño debido a los comandos que superaban el ancho esperado 


- Antes
![image](https://github.com/user-attachments/assets/5cb7bf57-6358-4edb-afbc-9234b56e9d84)


- Despues 

![image](https://github.com/user-attachments/assets/998ed0a5-9e95-4787-880c-ed0669c32c0a)
